### PR TITLE
fix: useProvider의 렌더링 시점 변경

### DIFF
--- a/src/app/user-providers.tsx
+++ b/src/app/user-providers.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import type { ReactNode } from "react"
+import { useEffect, type ReactNode } from "react"
 import type { User } from "@/utils/supabase"
 import useUserStore from "store/userStore"
 
@@ -13,7 +13,9 @@ export default function UserProvider({
   initialUser,
   children,
 }: UserProviderProps) {
-  useUserStore.setState({ loggedInUser: initialUser })
+  useEffect(() => {
+    useUserStore.setState({ loggedInUser: initialUser })
+  }, [initialUser])
 
   return children
 }


### PR DESCRIPTION
## 상황
> 불필요한 리랜더링 발생
- 기존 useProvider는 조건에 따라 챌린지 생성 페이지의 상태를 변경 시킴
- useProvider가 렌더링 중 챌린지 생성페이지의 값이 변경 되면 리렌더링



## 해결 방법
- useProvider는 렌더링 이후 필요한 값만 넘겨 받는 구조로 변경
- 컴포넌트 렌더링을 끝나면 그때 다른 컴포넌트 업데이트 진행
  - 렌더링 이후 실행되게 useEffect 추가

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] ESLint 검사를 하였습니다.

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택하세요. -->
<!-- 에시 : resolves #1 -->

resolves #109 
