### PR TITLE
refactor: 생성페이지의 썸네일 파일명을 정규 표현식으로 안전하게 변경

### DIFF
--- a/src/app/challenges/create/utils/handleChallengeSubmit.ts
+++ b/src/app/challenges/create/utils/handleChallengeSubmit.ts
@@ -13,6 +13,12 @@ export async function handleChallengeSubmit({
 }) {
   try {
     if (!data.thumbnail) throw new Error("썸네일 선택 필요")
+    if (data.thumbnail instanceof File) {
+      const safeName = data.thumbnail.name.replace(/[^\w.-]/g, "_")
+      data.thumbnail = new File([data.thumbnail], safeName, {
+        type: data.thumbnail.type,
+      })
+    }
     const thumbnailUrl = await upload(data.thumbnail)
 
     await createChallenge({ ...data, thumbnail: thumbnailUrl })


### PR DESCRIPTION
## PR 내용

- 슈퍼베이스는 한글, 일본어, 공백은 invalid key를 유발하므로 정규표현식으로 파일명을 안전하게 변경

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] ESLint 검사를 하였습니다.

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택하세요. -->
<!-- 에시 : resolves #1 -->

resolves #196 
