### PR TITLE
fix: 메인페이지 오픈그래프 수정 & 챌린지 카드 참여중 인원 통일

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,12 +28,21 @@ export const metadata: Metadata = {
       "일상을 변화시키는 새로운 챌린지에 참여하고, 다양한 사람들과 함께 성장하세요.",
     type: "website",
     siteName: "Minimo",
+    images: [
+      {
+        url: "/logo.svg",
+        width: 1200,
+        height: 630,
+        alt: "Minimo 로고",
+      },
+    ],
   },
   twitter: {
     card: "summary_large_image",
     title: "Minimo - 작은 챌린지, 큰 변화",
     description:
       "일상을 변화시키는 새로운 챌린지에 참여하고, 다양한 사람들과 함께 성장하세요.",
+    images: ["/logo.svg"],
   },
 }
 

--- a/src/components/challenge/hot-challenge-carousel/hot-challenge-carousel.tsx
+++ b/src/components/challenge/hot-challenge-carousel/hot-challenge-carousel.tsx
@@ -6,13 +6,13 @@ import { Swiper, SwiperSlide } from "swiper/react"
 import "swiper/css"
 import "swiper/css/navigation"
 import ChallengeCard from "@/components/common/challenge-card/challenge-card"
-import type { Challenge } from "@/utils/supabase"
+import type { ChallengeWithParticipants } from "@/utils/supabase"
 import type { ChallengeWithOwner } from "@/utils/supabase/api/search"
 import styles from "./hot-challenge-carousel.module.css"
 
 interface HotChallengeCarouselProps {
   title: string
-  challenges: (Challenge | ChallengeWithOwner)[]
+  challenges: (ChallengeWithParticipants | ChallengeWithOwner)[]
 }
 
 export default function HotChallengeCarousel({
@@ -44,7 +44,7 @@ export default function HotChallengeCarousel({
   const CARDS_PER_SLIDE =
     viewport === "desktop" ? 5 : viewport === "tablet" ? 3 : 1
 
-  const slideGroups: (Challenge | ChallengeWithOwner)[][] = []
+  const slideGroups: (ChallengeWithParticipants | ChallengeWithOwner)[][] = []
   for (let i = 0; i < displayChallenges.length; i += CARDS_PER_SLIDE) {
     slideGroups.push(displayChallenges.slice(i, i + CARDS_PER_SLIDE))
   }
@@ -71,6 +71,10 @@ export default function HotChallengeCarousel({
                       <ChallengeCard
                         challenge={challenge}
                         participantCount={challenge.participants_count}
+                        realParticipantCount={
+                          "participants" in challenge &&
+                          challenge.participants?.[0]?.count
+                        }
                         daysLeft={Math.ceil(
                           (new Date(challenge.end_at).getTime() -
                             new Date(challenge.start_at).getTime()) /
@@ -87,6 +91,10 @@ export default function HotChallengeCarousel({
                         <ChallengeCard
                           challenge={group[0]}
                           participantCount={group[0].participants_count}
+                          realParticipantCount={
+                            "participants" in group[0] &&
+                            group[0].participants?.[0]?.count
+                          }
                           daysLeft={Math.ceil(
                             (new Date(group[0].end_at).getTime() -
                               new Date(group[0].start_at).getTime()) /
@@ -102,6 +110,10 @@ export default function HotChallengeCarousel({
                           <ChallengeCard
                             challenge={challenge}
                             participantCount={challenge.participants_count}
+                            realParticipantCount={
+                              "participants" in challenge &&
+                              challenge.participants?.[0]?.count
+                            }
                             daysLeft={Math.ceil(
                               (new Date(challenge.end_at).getTime() -
                                 new Date(challenge.start_at).getTime()) /

--- a/src/components/common/challenge-card-list/challenge-card-list.tsx
+++ b/src/components/common/challenge-card-list/challenge-card-list.tsx
@@ -2,7 +2,7 @@
 
 import { Navigation } from "swiper/modules"
 import { Swiper, SwiperSlide } from "swiper/react"
-import type { Challenge } from "@/utils/supabase"
+import type { ChallengeWithParticipants } from "@/utils/supabase"
 import type { ChallengeWithOwner } from "@/utils/supabase/api/search"
 import "swiper/css"
 import "swiper/css/navigation"
@@ -11,10 +11,10 @@ import styles from "./challenge-card-list.module.css"
 
 interface ChallengeCardListProps {
   title?: string
-  challenges: (Challenge | ChallengeWithOwner)[]
+  challenges: (ChallengeWithParticipants | ChallengeWithOwner)[]
   className?: string
   renderCard?: (
-    challenge: Challenge | ChallengeWithOwner,
+    challenge: ChallengeWithParticipants | ChallengeWithOwner,
     index: number
   ) => React.ReactNode
 }
@@ -48,6 +48,10 @@ export default function ChallengeCardList({
                 <ChallengeCard
                   challenge={challenge}
                   participantCount={challenge.participants_count}
+                  realParticipantCount={
+                    "participants" in challenge &&
+                    challenge.participants?.[0]?.count
+                  }
                   daysLeft={Math.ceil(
                     (new Date(challenge.end_at).getTime() -
                       new Date(challenge.start_at).getTime()) /

--- a/src/components/common/challenge-card/challenge-card.tsx
+++ b/src/components/common/challenge-card/challenge-card.tsx
@@ -17,12 +17,14 @@ interface ChallengeCardProps {
   challenge: Challenge | ChallengeWithOwner
   participantCount?: number
   daysLeft?: number
+  realParticipantCount?: number
 }
 
 export default function ChallengeCard({
   challenge,
   participantCount = 0,
   daysLeft = 0,
+  realParticipantCount,
 }: ChallengeCardProps) {
   const router = useRouter()
   const { user } = useAuth()
@@ -139,8 +141,10 @@ export default function ChallengeCard({
             </div>
           )}
           <div className={styles.tags}>
-            {participantCount > 0 && (
-              <span className={styles.tag}>{participantCount}명 참여중</span>
+            {(realParticipantCount ?? participantCount) > 0 && (
+              <span className={styles.tag}>
+                {realParticipantCount ?? participantCount}명 참여중
+              </span>
             )}
             {daysLeft > 0 && (
               <span className={styles.tagDay}>{daysLeft}일</span>

--- a/src/components/home/home-challenges.tsx
+++ b/src/components/home/home-challenges.tsx
@@ -4,7 +4,7 @@ import { useEffect } from "react"
 import useSWR from "swr"
 import HotChallengeCarousel from "@/components/challenge/hot-challenge-carousel/hot-challenge-carousel"
 import ChallengeCardList from "@/components/common/challenge-card-list/challenge-card-list"
-import type { Challenge } from "@/utils/supabase"
+import type { ChallengeWithParticipants } from "@/utils/supabase"
 import {
   getHotChallengesClient,
   getNewChallengesClient,
@@ -33,11 +33,11 @@ const fetcher = async (url: string) => {
 }
 
 interface HomeChallengesProps {
-  initialHotChallenges: Challenge[]
-  initialNewChallenges: Challenge[]
-  initialPhotoChallenges: Challenge[]
-  initialWritingChallenges: Challenge[]
-  initialAttendanceChallenges: Challenge[]
+  initialHotChallenges: ChallengeWithParticipants[]
+  initialNewChallenges: ChallengeWithParticipants[]
+  initialPhotoChallenges: ChallengeWithParticipants[]
+  initialWritingChallenges: ChallengeWithParticipants[]
+  initialAttendanceChallenges: ChallengeWithParticipants[]
 }
 
 export default function HomeChallenges({

--- a/src/utils/supabase/api/challenges-client.ts
+++ b/src/utils/supabase/api/challenges-client.ts
@@ -1,17 +1,25 @@
 import browserClient from "../client"
-import type { Challenge } from ".."
+import type { ChallengeWithParticipants } from ".."
 
-export async function getHotChallengesClient(limit = 20): Promise<Challenge[]> {
+export async function getHotChallengesClient(
+  limit = 20
+): Promise<ChallengeWithParticipants[]> {
   const supabase = browserClient()
   const now = new Date().toISOString()
 
   const { data, error } = await supabase
     .from("challenges")
-    .select("*")
+    .select(
+      `
+      *,
+      participants:challenge_participants(count)
+    `
+    )
     .eq("is_public", true)
     .eq("is_finished", false)
     .lte("start_at", now)
     .gte("end_at", now)
+    .eq("challenge_participants.is_progress", true)
     .order("participants_count", { ascending: false })
     .order("id", { ascending: false })
     .limit(limit)
@@ -24,18 +32,24 @@ export async function getHotChallengesClient(limit = 20): Promise<Challenge[]> {
   return data || []
 }
 
-export async function getNewChallengesClient(limit = 20): Promise<Challenge[]> {
+export async function getNewChallengesClient(
+  limit = 20
+): Promise<ChallengeWithParticipants[]> {
   const supabase = browserClient()
-  const now = new Date().toISOString()
 
+  // start_at 필드를 기준으로 정렬 (챌린지 생성 시 설정되므로 생성 순서와 유사)
   const { data, error } = await supabase
     .from("challenges")
-    .select("*")
+    .select(
+      `
+      *,
+      participants:challenge_participants(count)
+    `
+    )
     .eq("is_public", true)
     .eq("is_finished", false)
-    .lte("start_at", now)
-    .gte("end_at", now)
-    .order("id", { ascending: false })
+    .eq("challenge_participants.is_progress", true)
+    .order("start_at", { ascending: false })
     .limit(limit)
 
   if (error) {
@@ -49,18 +63,24 @@ export async function getNewChallengesClient(limit = 20): Promise<Challenge[]> {
 export async function getChallengesByTypeClient(
   uploadingType: "사진 인증" | "텍스트 인증" | "출석체크 인증",
   limit = 20
-): Promise<Challenge[]> {
+): Promise<ChallengeWithParticipants[]> {
   const supabase = browserClient()
   const now = new Date().toISOString()
 
   const { data, error } = await supabase
     .from("challenges")
-    .select("*")
+    .select(
+      `
+      *,
+      participants:challenge_participants(count)
+    `
+    )
     .eq("is_public", true)
     .eq("is_finished", false)
     .eq("uploading_type", uploadingType)
     .lte("start_at", now)
     .gte("end_at", now)
+    .eq("challenge_participants.is_progress", true)
     .order("id", { ascending: false })
     .limit(limit)
 

--- a/src/utils/supabase/api/challenges-server.ts
+++ b/src/utils/supabase/api/challenges-server.ts
@@ -1,17 +1,25 @@
 import { createClient } from "../server"
-import type { Challenge } from ".."
+import type { ChallengeWithParticipants } from ".."
 
-export async function getHotChallenges(limit = 20): Promise<Challenge[]> {
+export async function getHotChallenges(
+  limit = 20
+): Promise<ChallengeWithParticipants[]> {
   const supabase = await createClient()
   const now = new Date().toISOString()
 
   const { data, error } = await supabase
     .from("challenges")
-    .select("*")
+    .select(
+      `
+      *,
+      participants:challenge_participants(count)
+    `
+    )
     .eq("is_public", true)
     .eq("is_finished", false)
     .lte("start_at", now)
     .gte("end_at", now)
+    .eq("challenge_participants.is_progress", true)
     .order("participants_count", { ascending: false })
     .order("id", { ascending: false })
     .limit(limit)
@@ -24,18 +32,24 @@ export async function getHotChallenges(limit = 20): Promise<Challenge[]> {
   return data || []
 }
 
-export async function getNewChallenges(limit = 20): Promise<Challenge[]> {
+export async function getNewChallenges(
+  limit = 20
+): Promise<ChallengeWithParticipants[]> {
   const supabase = await createClient()
-  const now = new Date().toISOString()
 
+  // start_at 필드를 기준으로 정렬 (챌린지 생성 시 설정되므로 생성 순서와 유사)
   const { data, error } = await supabase
     .from("challenges")
-    .select("*")
+    .select(
+      `
+      *,
+      participants:challenge_participants(count)
+    `
+    )
     .eq("is_public", true)
     .eq("is_finished", false)
-    .lte("start_at", now)
-    .gte("end_at", now)
-    .order("id", { ascending: false })
+    .eq("challenge_participants.is_progress", true)
+    .order("start_at", { ascending: false })
     .limit(limit)
 
   if (error) {
@@ -49,18 +63,24 @@ export async function getNewChallenges(limit = 20): Promise<Challenge[]> {
 export async function getChallengesByType(
   uploadingType: "사진 인증" | "텍스트 인증" | "출석체크 인증",
   limit = 20
-): Promise<Challenge[]> {
+): Promise<ChallengeWithParticipants[]> {
   const supabase = await createClient()
   const now = new Date().toISOString()
 
   const { data, error } = await supabase
     .from("challenges")
-    .select("*")
+    .select(
+      `
+      *,
+      participants:challenge_participants(count)
+    `
+    )
     .eq("is_public", true)
     .eq("is_finished", false)
     .eq("uploading_type", uploadingType)
     .lte("start_at", now)
     .gte("end_at", now)
+    .eq("challenge_participants.is_progress", true)
     .order("id", { ascending: false })
     .limit(limit)
 

--- a/src/utils/supabase/index.ts
+++ b/src/utils/supabase/index.ts
@@ -19,5 +19,8 @@ const supabase = createClient<Database>(
 export default supabase
 
 export type Challenge = Tables<"challenges">
+export type ChallengeWithParticipants = Challenge & {
+  participants?: { count: number }[]
+}
 export type ChallengeInsert = TablesInsert<"challenges">
 export type User = Tables<"users">


### PR DESCRIPTION
## PR 내용

<!-- PR에 대해 간단히 설명을 적으세요. -->

- 메인페이지 오픈그래프 이미지 수정
- 챌린지 카드컴포넌트 참여중 인원 수정
- 새로 생긴 챌린지 start-at 순으로 정렬(추후 db에 생성시각 필드를 추가하고 최신순 기능 리팩토링 예정)

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] ESLint 검사를 하였습니다.

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택하세요. -->
<!-- 에시 : resolves #1 -->

resolves #201 
