### PR TITLE
fix: 검색 페이지에서의 참여 인원 안보임 이슈 해결

### DIFF
--- a/src/components/common/challenge-card-list/challenge-card-list.tsx
+++ b/src/components/common/challenge-card-list/challenge-card-list.tsx
@@ -3,7 +3,6 @@
 import { Navigation } from "swiper/modules"
 import { Swiper, SwiperSlide } from "swiper/react"
 import type { ChallengeWithParticipants } from "@/utils/supabase"
-import type { ChallengeWithOwner } from "@/utils/supabase/api/search"
 import "swiper/css"
 import "swiper/css/navigation"
 import ChallengeCard from "../challenge-card/challenge-card"
@@ -11,10 +10,10 @@ import styles from "./challenge-card-list.module.css"
 
 interface ChallengeCardListProps {
   title?: string
-  challenges: (ChallengeWithParticipants | ChallengeWithOwner)[]
+  challenges: ChallengeWithParticipants[]
   className?: string
   renderCard?: (
-    challenge: ChallengeWithParticipants | ChallengeWithOwner,
+    challenge: ChallengeWithParticipants,
     index: number
   ) => React.ReactNode
 }
@@ -48,10 +47,7 @@ export default function ChallengeCardList({
                 <ChallengeCard
                   challenge={challenge}
                   participantCount={challenge.participants_count}
-                  realParticipantCount={
-                    "participants" in challenge &&
-                    challenge.participants?.[0]?.count
-                  }
+                  realParticipantCount={challenge.participants?.[0]?.count}
                   daysLeft={Math.ceil(
                     (new Date(challenge.end_at).getTime() -
                       new Date(challenge.start_at).getTime()) /


### PR DESCRIPTION
## PR 내용

검색 페이지에서 카드 컴포넌트의 참여 인원이 안보이는 이슈 해결
realParticipantCount={"participants" in challenge &&}
코드 부분에서 challenge의 "participants"가 false 라서 참여 인원을 불러오는 코드가 실행 되지 않음

## 추가 이슈
- 각 페이지에서 참여 인원이 다 다르게 보임
- 탐색, 메인, 검색 등등..

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] ESLint 검사를 하였습니다.

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택하세요. -->
<!-- 에시 : resolves #1 -->

resolves #214 
